### PR TITLE
Make patterns easier to read by not including 'what is it'

### DIFF
--- a/_layouts/pattern.html
+++ b/_layouts/pattern.html
@@ -5,7 +5,7 @@ layout: default
 <h3>Pattern: {{page.title}}</h3>
 
 <p>
-    <strong>What is it?</strong> {{page.tagline}}
+    {{page.tagline}}
 </p>
 
 {% if page.stub %}


### PR DESCRIPTION
Would love some input on this. Basically I'm just getting rid of the 'What is it text?' so that patterns are easier to read. The text feels redundant to me.
